### PR TITLE
Hijacked LoadSavedWMStuff.

### DIFF
--- a/Wizardry/ExpandedModularSave/ExModularSaveInternals.event
+++ b/Wizardry/ExpandedModularSave/ExModularSaveInternals.event
@@ -63,6 +63,10 @@ PUSH
 	ORG $0A524C
 		LynJump(MS_GetClaimFlagsFromGameSave)
 
+	// Replace LoadSavedWMStuff
+	ORG $0A5274
+		LynJump(MS_LoadWMDataFromGameSave)
+
 	// Replace LoadSavedEid8A
 	ORG $0A5290
 		LynJump(MS_CheckEid8AFromGameSave)


### PR DESCRIPTION
LoadSavedWMStuff (0x80A5274) was using the vanilla offset for saved WMData. This inserts Stan's replacement for this function, which uses the offset determined by the user.

This should fix the issue where an incorrect chapter title is displayed for save files which were created during a skirmish, which seems to be the only time LoadSavedWMStuff is called.